### PR TITLE
#12 Melhorar a formatação do JSON

### DIFF
--- a/src/AttributeInfo.c
+++ b/src/AttributeInfo.c
@@ -11,13 +11,17 @@ ConstantValueAttribute ConstantValueAttribute_read(FILE *fp)
   return constant_value_attribute;
 }
 
-char *ConstantValueAttribute_to_string(ConstantValueAttribute constant_value_attribute, ConstantPool constant_pool)
+char *ConstantValueAttribute_to_string(
+    ConstantValueAttribute constant_value_attribute, ConstantPool constant_pool)
 {
   char *str = (char *)malloc(100 * sizeof(char));
+  char *constant_value_utf8 = ConstantPool_get_utf8(
+      constant_pool, constant_value_attribute.constantvalue_index);
   snprintf(
       str, 100,
-      "\"constantvalue_index\":\"#%d\"",
-      constant_value_attribute.constantvalue_index);
+      "\"constantvalue_index\":\"#%d // %s\"",
+      constant_value_attribute.constantvalue_index, constant_value_utf8);
+  free(constant_value_utf8);
   return str;
 }
 
@@ -179,10 +183,18 @@ SourceFileAttribute SourceFileAttribute_read(FILE *fp)
   return source_file_attribute;
 }
 
-char *SourceFileAttribute_to_string(SourceFileAttribute source_file_attribute)
+char *SourceFileAttribute_to_string(
+    SourceFileAttribute source_file_attribute,
+    ConstantPool constant_pool)
 {
   char *str = (char *)malloc(256 * sizeof(char));
-  snprintf(str, 256, "\"sourcefile_index\":\"#%d\"", source_file_attribute.sourcefile_index);
+  char *sourcefile_utf8 = ConstantPool_get_utf8(
+      constant_pool, source_file_attribute.sourcefile_index);
+  snprintf(
+      str, 256,
+      "\"sourcefile_index\":\"#%d // %s\"",
+      source_file_attribute.sourcefile_index, sourcefile_utf8);
+  free(sourcefile_utf8);
   return str;
 }
 
@@ -321,19 +333,23 @@ char *AttributeInfo_to_string(
     }
     else if (!strcmp(type, "SourceFile"))
     {
-      str_union = SourceFileAttribute_to_string(attribute->source_file);
+      str_union = SourceFileAttribute_to_string(
+          attribute->source_file, constant_pool);
     }
     else
     {
       str_union = UnknownAttribute_to_string(attribute->unknown, attribute->attribute_length);
     }
     char separator = attribute == attribute_infos + attributes_count - 1 ? ']' : ',';
+    char *attribute_name_utf8 = ConstantPool_get_utf8(
+        constant_pool, attribute->attribute_name_index);
     snprintf(
         str_temp, 65536,
-        "%s{\"attribute_name_index\":\"#%d\",\"attribute_lenght\":%d,%s}%c",
-        str, attribute->attribute_name_index, attribute->attribute_length, str_union,
-        separator);
+        "%s{\"attribute_name_index\":\"#%d // %s\",\"attribute_lenght\":%d,%s}%c",
+        str, attribute->attribute_name_index, attribute_name_utf8,
+        attribute->attribute_length, str_union, separator);
     free(str_union);
+    free(attribute_name_utf8);
     free(str);
     str = str_temp;
   }

--- a/src/ClassFile.c
+++ b/src/ClassFile.c
@@ -100,6 +100,30 @@ char *ClassFile_major_version_to_string(u2 major_version)
   return version_string;
 }
 
+char *ClassFile_access_flags_to_string(u2 access_flags)
+{
+  const char *acc_public_string = access_flags & 0x0001 ? "public " : "";
+  const char *acc_final_string = access_flags & 0x0010 ? "final " : "";
+  const char *acc_super_string = access_flags & 0x0020 ? "super " : "";
+  const char *acc_interface_string = access_flags & 0x0200 ? "interface " : "";
+  const char *acc_abstract_string = access_flags & 0x0400 ? "abstract " : "";
+  const char *acc_synthetic_string = access_flags & 0x1000 ? "synthetic " : "";
+  const char *acc_annotation_string = access_flags & 0x2000 ? "annotation " : "";
+  const char *acc_enum_string = access_flags & 0x4000 ? "enum " : "";
+  char *access_flags_string = (char *)malloc(1024);
+  snprintf(
+      access_flags_string, 1024,
+      "%s%s%s%s%s%s%s%s",
+      acc_public_string, acc_final_string, acc_super_string,
+      acc_interface_string, acc_abstract_string, acc_synthetic_string,
+      acc_annotation_string, acc_enum_string);
+  if (strlen(access_flags_string) > 0)
+  {
+    access_flags_string[strlen(access_flags_string) - 1] = '\0'; // remove last space
+  }
+  return access_flags_string;
+}
+
 char *ClassFile_intefarces_to_string(ClassFile c)
 {
   char *interfaces_string = (char *)malloc(1000);
@@ -131,8 +155,10 @@ char *ClassFile_to_string(ClassFile c)
       c.major_version);
   char *constant_pool_string = ConstantPool_to_string(
       c.constant_pool, c.constant_pool_count);
+  char *access_flags_string = ClassFile_access_flags_to_string(c.access_flags);
   char *this_class_utf8 = ConstantPool_get_utf8(c.constant_pool, c.this_class);
-  char *super_class_utf8 = ConstantPool_get_utf8(c.constant_pool, c.super_class);
+  char *super_class_utf8 = ConstantPool_get_utf8(
+      c.constant_pool, c.super_class);
   char *interfaces_string = ClassFile_intefarces_to_string(c);
   char *fields_string = FieldInfo_to_string(
       c.fields, c.fields_count, c.constant_pool);
@@ -144,17 +170,21 @@ char *ClassFile_to_string(ClassFile c)
       class_file_string, 1000000,
       "{\"magic_number\":\"0x%X\",\"minor_version\":%d,"
       "\"major_version\":\"%d [%s]\",\"constant_pool_count\":%d,"
-      "\"constant_pool\":%s,\"access_flags\":%d,\"this_class\":\"#%d // %s\","
+      "\"constant_pool\":%s,\"access_flags\":\"0x%04X [%s]\","
+      "\"this_class\":\"#%d // %s\","
       "\"super_class\":\"#%d // %s\",\"interfaces_count\":%d,\"interfaces\":%s,"
       "\"fields_count\":%d,\"fields\":%s,\"methods_count\":%d,\"methods\":%s,"
       "\"attributes_count\":%d,\"attributes\":%s}",
-      c.magic_number, c.minor_version, c.major_version, major_version_string,
-      c.constant_pool_count, constant_pool_string, c.access_flags, c.this_class,
-      this_class_utf8, c.super_class, super_class_utf8, c.interfaces_count,
-      interfaces_string, c.fields_count, fields_string, c.methods_count,
-      methods_string, c.attributes_count, attributes_string);
+      c.magic_number, c.minor_version,
+      c.major_version, major_version_string, c.constant_pool_count,
+      constant_pool_string, c.access_flags, access_flags_string,
+      c.this_class, this_class_utf8,
+      c.super_class, super_class_utf8, c.interfaces_count, interfaces_string,
+      c.fields_count, fields_string, c.methods_count, methods_string,
+      c.attributes_count, attributes_string);
   free(major_version_string);
   free(constant_pool_string);
+  free(access_flags_string);
   free(this_class_utf8);
   free(super_class_utf8);
   free(interfaces_string);

--- a/src/ClassFile.c
+++ b/src/ClassFile.c
@@ -112,7 +112,12 @@ char *ClassFile_intefarces_to_string(ClassFile c)
   {
     char *tmp = (char *)malloc(1000);
     char comma = i == c.interfaces_count - 1 ? ']' : ',';
-    sprintf(tmp, "%s\"#%d\"%c", interfaces_string, c.interfaces[i], comma);
+    char *interface_utf8 = ConstantPool_get_utf8(
+        c.constant_pool, c.interfaces[i]);
+    snprintf(
+        tmp, 1000,
+        "%s\"#%d // %s\"%c",
+        interfaces_string, c.interfaces[i], interface_utf8, comma);
     free(interfaces_string);
     interfaces_string = tmp;
   }
@@ -126,6 +131,8 @@ char *ClassFile_to_string(ClassFile c)
       c.major_version);
   char *constant_pool_string = ConstantPool_to_string(
       c.constant_pool, c.constant_pool_count);
+  char *this_class_utf8 = ConstantPool_get_utf8(c.constant_pool, c.this_class);
+  char *super_class_utf8 = ConstantPool_get_utf8(c.constant_pool, c.super_class);
   char *interfaces_string = ClassFile_intefarces_to_string(c);
   char *fields_string = FieldInfo_to_string(
       c.fields, c.fields_count, c.constant_pool);
@@ -137,17 +144,19 @@ char *ClassFile_to_string(ClassFile c)
       class_file_string, 1000000,
       "{\"magic_number\":\"0x%X\",\"minor_version\":%d,"
       "\"major_version\":\"%d [%s]\",\"constant_pool_count\":%d,"
-      "\"constant_pool\":%s,\"access_flags\":%d,\"this_class\":\"#%d\","
-      "\"super_class\":\"#%d\",\"interfaces_count\":%d,\"interfaces\":%s,"
+      "\"constant_pool\":%s,\"access_flags\":%d,\"this_class\":\"#%d // %s\","
+      "\"super_class\":\"#%d // %s\",\"interfaces_count\":%d,\"interfaces\":%s,"
       "\"fields_count\":%d,\"fields\":%s,\"methods_count\":%d,\"methods\":%s,"
       "\"attributes_count\":%d,\"attributes\":%s}",
       c.magic_number, c.minor_version, c.major_version, major_version_string,
       c.constant_pool_count, constant_pool_string, c.access_flags, c.this_class,
-      c.super_class, c.interfaces_count, interfaces_string, c.fields_count,
-      fields_string, c.methods_count, methods_string, c.attributes_count,
-      attributes_string);
+      this_class_utf8, c.super_class, super_class_utf8, c.interfaces_count,
+      interfaces_string, c.fields_count, fields_string, c.methods_count,
+      methods_string, c.attributes_count, attributes_string);
   free(major_version_string);
   free(constant_pool_string);
+  free(this_class_utf8);
+  free(super_class_utf8);
   free(interfaces_string);
   free(fields_string);
   free(methods_string);

--- a/src/ClassFile.c
+++ b/src/ClassFile.c
@@ -4,6 +4,7 @@
 #include "java-bytes.h"
 #include <stdio.h>  // sprintf
 #include <stdlib.h> // malloc
+#include <string.h> // strcpy
 
 ClassFile ClassFile_read(FILE *fp)
 {
@@ -31,6 +32,74 @@ ClassFile ClassFile_read(FILE *fp)
   return c;
 }
 
+char *ClassFile_major_version_to_string(u2 major_version)
+{
+  char *version_string = (char *)malloc(100);
+  switch (major_version)
+  {
+  case 45:
+    strcpy(version_string, "1.1");
+    break;
+  case 46:
+    strcpy(version_string, "1.2");
+    break;
+  case 47:
+    strcpy(version_string, "1.3");
+    break;
+  case 48:
+    strcpy(version_string, "1.4");
+    break;
+  case 49:
+    strcpy(version_string, "1.5");
+    break;
+  case 50:
+    strcpy(version_string, "1.6");
+    break;
+  case 51:
+    strcpy(version_string, "1.7");
+    break;
+  case 52:
+    strcpy(version_string, "1.8");
+    break;
+  case 53:
+    strcpy(version_string, "1.9");
+    break;
+  case 54:
+    strcpy(version_string, "1.10");
+    break;
+  case 55:
+    strcpy(version_string, "1.11");
+    break;
+  case 56:
+    strcpy(version_string, "1.12");
+    break;
+  case 57:
+    strcpy(version_string, "1.13");
+    break;
+  case 58:
+    strcpy(version_string, "1.14");
+    break;
+  case 59:
+    strcpy(version_string, "1.15");
+    break;
+  case 60:
+    strcpy(version_string, "1.16");
+    break;
+  case 61:
+    strcpy(version_string, "1.17");
+    break;
+  case 62:
+    strcpy(version_string, "1.18");
+    break;
+  case 63:
+    strcpy(version_string, "1.19");
+    break;
+  default:
+    strcpy(version_string, "unknown");
+  }
+  return version_string;
+}
+
 char *ClassFile_intefarces_to_string(ClassFile c)
 {
   char *interfaces_string = (char *)malloc(1000);
@@ -53,18 +122,31 @@ char *ClassFile_intefarces_to_string(ClassFile c)
 char *ClassFile_to_string(ClassFile c)
 {
   char *class_file_string = (char *)malloc(1000000);
-  char *constant_pool_string = ConstantPool_to_string(c.constant_pool, c.constant_pool_count);
+  char *major_version_string = ClassFile_major_version_to_string(
+      c.major_version);
+  char *constant_pool_string = ConstantPool_to_string(
+      c.constant_pool, c.constant_pool_count);
   char *interfaces_string = ClassFile_intefarces_to_string(c);
-  char *fields_string = FieldInfo_to_string(c.fields, c.fields_count, c.constant_pool);
-  char *methods_string = MethodInfo_to_string(c.methods, c.methods_count, c.constant_pool);
-  char *attributes_string = AttributeInfo_to_string(c.attributes, c.attributes_count, c.constant_pool);
+  char *fields_string = FieldInfo_to_string(
+      c.fields, c.fields_count, c.constant_pool);
+  char *methods_string = MethodInfo_to_string(
+      c.methods, c.methods_count, c.constant_pool);
+  char *attributes_string = AttributeInfo_to_string(
+      c.attributes, c.attributes_count, c.constant_pool);
   snprintf(
       class_file_string, 1000000,
-      "{\"__cls\":\"ClassFile\",\"magic_number\":\"0x%X\",\"minor_version\":%d,\"major_version\":%d,\"constant_pool_count\":%d,\"constant_pool\":%s,\"access_flags\":%d,\"this_class\":\"#%d\",\"super_class\":\"#%d\",\"interfaces_count\":%d,\"interfaces\":%s,\"fields_count\":%d,\"fields\":%s,\"methods_count\":%d,\"methods\":%s,\"attributes_count\":%d,\"attributes\":%s}",
-      c.magic_number, c.minor_version, c.major_version, c.constant_pool_count, constant_pool_string,
-      c.access_flags, c.this_class, c.super_class, c.interfaces_count, interfaces_string,
-      c.fields_count, fields_string, c.methods_count, methods_string, c.attributes_count,
+      "{\"magic_number\":\"0x%X\",\"minor_version\":%d,"
+      "\"major_version\":\"%d [%s]\",\"constant_pool_count\":%d,"
+      "\"constant_pool\":%s,\"access_flags\":%d,\"this_class\":\"#%d\","
+      "\"super_class\":\"#%d\",\"interfaces_count\":%d,\"interfaces\":%s,"
+      "\"fields_count\":%d,\"fields\":%s,\"methods_count\":%d,\"methods\":%s,"
+      "\"attributes_count\":%d,\"attributes\":%s}",
+      c.magic_number, c.minor_version, c.major_version, major_version_string,
+      c.constant_pool_count, constant_pool_string, c.access_flags, c.this_class,
+      c.super_class, c.interfaces_count, interfaces_string, c.fields_count,
+      fields_string, c.methods_count, methods_string, c.attributes_count,
       attributes_string);
+  free(major_version_string);
   free(constant_pool_string);
   free(interfaces_string);
   free(fields_string);

--- a/src/ConstantPool.c
+++ b/src/ConstantPool.c
@@ -1,9 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "ConstantPool.h"
+#include <string.h>
 
-// ConstantMethodrefInfo ///////////////////////////////////////////////////////////////////////////
-
+// ConstantMethodrefInfo ///////////////////////////////////////////////////////
 ConstantMethodrefInfo ConstantMethodrefInfo_read(FILE *fp)
 {
   ConstantMethodrefInfo cfi;
@@ -12,15 +12,33 @@ ConstantMethodrefInfo ConstantMethodrefInfo_read(FILE *fp)
   return cfi;
 };
 
-char *ConstantMethodrefInfo_to_string(ConstantMethodrefInfo cfi)
+char *ConstantMethodrefInfo_get_utf8(ConstantMethodrefInfo cfi, ConstantPool cp)
+{
+  char *class_string = ConstantPool_get_utf8(cp, cfi.class_index);
+  char *name_and_type_string = ConstantPool_get_utf8(cp, cfi.name_and_type_index);
+  char *s = (char *)malloc(256);
+  snprintf(s, 256, "%s.%s", class_string, name_and_type_string);
+  free(class_string);
+  free(name_and_type_string);
+  return s;
+}
+
+char *ConstantMethodrefInfo_to_string(ConstantMethodrefInfo cfi, ConstantPool cp)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cfi.class_index, cfi.name_and_type_index);
+  char *class_string = ConstantPool_get_utf8(cp, cfi.class_index);
+  char *name_and_type_string = ConstantPool_get_utf8(cp, cfi.name_and_type_index);
+  snprintf(
+      s, 256,
+      "{\"class_index\":\"#%d // %s \",\"name_and_type_index\":\"#%d // %s\"}",
+      cfi.class_index, class_string, cfi.name_and_type_index,
+      name_and_type_string);
+  free(class_string);
+  free(name_and_type_string);
   return s;
 };
 
-// ConstantFieldrefInfo ////////////////////////////////////////////////////////////////////////////
-
+// ConstantFieldrefInfo ////////////////////////////////////////////////////////
 ConstantFieldrefInfo ConstantFieldrefInfo_read(FILE *fp)
 {
   ConstantFieldrefInfo cfi;
@@ -29,15 +47,37 @@ ConstantFieldrefInfo ConstantFieldrefInfo_read(FILE *fp)
   return cfi;
 };
 
-char *ConstantFieldrefInfo_to_string(ConstantFieldrefInfo cfi)
+char *ConstantFieldrefInfo_get_utf8(ConstantFieldrefInfo cfi, ConstantPool cp)
+{
+  char *class_string = ConstantPool_get_utf8(cp, cfi.class_index);
+  char *name_and_type_string = ConstantPool_get_utf8(
+      cp, cfi.name_and_type_index);
+  char *s = (char *)malloc(256);
+  snprintf(
+      s, 256,
+      "%s.%s", class_string, name_and_type_string);
+  free(class_string);
+  free(name_and_type_string);
+  return s;
+}
+
+char *ConstantFieldrefInfo_to_string(ConstantFieldrefInfo cfi, ConstantPool cp)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cfi.class_index, cfi.name_and_type_index);
+  char *class_string = ConstantPool_get_utf8(cp, cfi.class_index);
+  char *name_and_type_string = ConstantPool_get_utf8(
+      cp, cfi.name_and_type_index);
+  snprintf(
+      s, 256,
+      "{\"class_index\":\"#%d // %s\",\"name_and_type_index\":\"#%d // %s\"}",
+      cfi.class_index, class_string, cfi.name_and_type_index,
+      name_and_type_string);
+  free(class_string);
+  free(name_and_type_string);
   return s;
 };
 
-// ConstantFloatInfo ///////////////////////////////////////////////////////////////////////////////
-
+// ConstantFloatInfo ///////////////////////////////////////////////////////////
 ConstantFloatInfo ConstantFloatInfo_read(FILE *fp)
 {
   ConstantFloatInfo cfi;
@@ -48,15 +88,21 @@ ConstantFloatInfo ConstantFloatInfo_read(FILE *fp)
   return cfi;
 };
 
+char *ConstantFloatInfo_get_utf8(ConstantFloatInfo cfi)
+{
+  char *s = (char *)malloc(256);
+  sprintf(s, "%f", cfi.bytes);
+  return s;
+}
+
 char *ConstantFloatInfo_to_string(ConstantFloatInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"bytes\":%f}", cfi.bytes);
+  sprintf(s, "{\"float\":%f}", cfi.bytes);
   return s;
 };
 
-// ConstantLongInfo ////////////////////////////////////////////////////////////////////////////////
-
+// ConstantLongInfo ////////////////////////////////////////////////////////////
 ConstantLongInfo ConstantLongInfo_read(FILE *fp)
 {
   ConstantLongInfo cfi;
@@ -66,15 +112,21 @@ ConstantLongInfo ConstantLongInfo_read(FILE *fp)
   return cfi;
 };
 
-char *ConstantLongInfo_to_string(ConstantLongInfo cfi)
+char *ConstantLongInfo_get_utf8(ConstantLongInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"bytes\":%ld}", cfi.bytes);
+  sprintf(s, "%ld", cfi.bytes);
   return s;
 };
 
-// ConstantDoubleInfo //////////////////////////////////////////////////////////////////////////////
+char *ConstantLongInfo_to_string(ConstantLongInfo cfi)
+{
+  char *s = (char *)malloc(256);
+  sprintf(s, "{\"long\":%ld}", cfi.bytes);
+  return s;
+};
 
+// ConstantDoubleInfo //////////////////////////////////////////////////////////
 ConstantDoubleInfo ConstantDoubleInfo_read(FILE *fp)
 {
   ConstantDoubleInfo cfi;
@@ -86,6 +138,13 @@ ConstantDoubleInfo ConstantDoubleInfo_read(FILE *fp)
   return cfi;
 };
 
+char *ConstantDoubleInfo_get_utf8(ConstantDoubleInfo cfi)
+{
+  char *s = (char *)malloc(256);
+  sprintf(s, "%f", cfi.bytes);
+  return s;
+}
+
 char *ConstantDoubleInfo_to_string(ConstantDoubleInfo cfi)
 {
   char *s = (char *)malloc(256);
@@ -93,8 +152,7 @@ char *ConstantDoubleInfo_to_string(ConstantDoubleInfo cfi)
   return s;
 };
 
-// ConstantStringInfo //////////////////////////////////////////////////////////////////////////////
-
+// ConstantStringInfo //////////////////////////////////////////////////////////
 ConstantStringInfo ConstantStringInfo_read(FILE *fp)
 {
   ConstantStringInfo csi;
@@ -102,15 +160,21 @@ ConstantStringInfo ConstantStringInfo_read(FILE *fp)
   return csi;
 };
 
-char *ConstantStringInfo_to_string(ConstantStringInfo csi)
+char *ConstantStringInfo_get_utf8(ConstantStringInfo csi, ConstantPool cp)
+{
+  return ConstantPool_get_utf8(cp, csi.string_index);
+}
+
+char *ConstantStringInfo_to_string(ConstantStringInfo csi, ConstantPool cp)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"string_index\":\"#%d\"}", csi.string_index);
+  char *utf8 = ConstantPool_get_utf8(cp, csi.string_index);
+  sprintf(s, "{\"string_index\":\"#%d // %s\"}", csi.string_index, utf8);
+  free(utf8);
   return s;
 };
 
-// ConstantClassInfo ///////////////////////////////////////////////////////////////////////////////
-
+// ConstantClassInfo ///////////////////////////////////////////////////////////
 ConstantClassInfo ConstantClassInfo_read(FILE *fp)
 {
   ConstantClassInfo cci;
@@ -118,15 +182,21 @@ ConstantClassInfo ConstantClassInfo_read(FILE *fp)
   return cci;
 };
 
-char *ConstantClassInfo_to_string(ConstantClassInfo cci)
+char *ConstantClassInfo_to_string(ConstantClassInfo cci, ConstantPool cp)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"name_index\":\"#%d\"}", cci.name_index);
+  char *name_utf8 = ConstantPool_get_utf8(cp, cci.name_index);
+  sprintf(s, "{\"name_index\":\"#%d // %s\"}", cci.name_index, name_utf8);
+  free(name_utf8);
   return s;
 };
 
-// ConstantInterfaceMethodrefInfo //////////////////////////////////////////////////////////////////
+char *ConstantClassInfo_get_utf8(ConstantClassInfo cci, ConstantPool cp)
+{
+  return ConstantPool_get_utf8(cp, cci.name_index);
+}
 
+// ConstantInterfaceMethodrefInfo //////////////////////////////////////////////
 ConstantInterfaceMethodrefInfo ConstantInterfaceMethodrefInfo_read(FILE *fp)
 {
   ConstantInterfaceMethodrefInfo cimi;
@@ -135,15 +205,37 @@ ConstantInterfaceMethodrefInfo ConstantInterfaceMethodrefInfo_read(FILE *fp)
   return cimi;
 };
 
-char *ConstantInterfaceMethodrefInfo_to_string(ConstantInterfaceMethodrefInfo cimi)
+char *ConstantInterfaceMethodrefInfo_get_utf8(
+    ConstantInterfaceMethodrefInfo cimi, ConstantPool cp)
+{
+  char *class_utf8 = ConstantPool_get_utf8(cp, cimi.class_index);
+  char *name_and_type_utf8 = ConstantPool_get_utf8(
+      cp, cimi.name_and_type_index);
+  char *s = (char *)malloc(256);
+  sprintf(s, "%s.%s", class_utf8, name_and_type_utf8);
+  free(class_utf8);
+  free(name_and_type_utf8);
+  return s;
+}
+
+char *ConstantInterfaceMethodrefInfo_to_string(
+    ConstantInterfaceMethodrefInfo cimi, ConstantPool cp)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cimi.class_index, cimi.name_and_type_index);
+  char *class_string = ConstantPool_get_utf8(cp, cimi.class_index);
+  char *name_and_type_string = ConstantPool_get_utf8(
+      cp, cimi.name_and_type_index);
+  snprintf(
+      s, 256,
+      "{\"class_index\":\"#%d // %s\",\"name_and_type_index\":\"#%d // %s\"}",
+      cimi.class_index, class_string, cimi.name_and_type_index,
+      name_and_type_string);
+  free(class_string);
+  free(name_and_type_string);
   return s;
 };
 
-// ConstantUtf8Info ////////////////////////////////////////////////////////////////////////////////
-
+// ConstantUtf8Info ////////////////////////////////////////////////////////////
 ConstantUtf8Info ConstantUtf8Info_read(FILE *fp)
 {
   ConstantUtf8Info cui;
@@ -161,8 +253,14 @@ char *ConstantUtf8Info_to_string(ConstantUtf8Info cui)
   return s;
 };
 
-// ConstantIntegerInfo /////////////////////////////////////////////////////////////////////////////
+char *ConstantUtf8Info_get_utf8(ConstantUtf8Info cui, ConstantPool cp)
+{
+  char *s = (char *)malloc(cui.length + 1);
+  strcpy(s, cui.bytes);
+  return s;
+}
 
+// ConstantIntegerInfo /////////////////////////////////////////////////////////
 ConstantIntegerInfo ConstantIntegerInfo_read(FILE *fp)
 {
   ConstantIntegerInfo cii;
@@ -170,15 +268,21 @@ ConstantIntegerInfo ConstantIntegerInfo_read(FILE *fp)
   return cii;
 };
 
-char *ConstantIntegerInfo_to_string(ConstantIntegerInfo cii)
+char *ConstantIntegerInfo_get_utf8(ConstantIntegerInfo cii)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"bytes\":%d}", cii.bytes);
+  sprintf(s, "%d", cii.bytes);
   return s;
 };
 
-// ConstantNameAndTypeInfo /////////////////////////////////////////////////////////////////////////
+char *ConstantIntegerInfo_to_string(ConstantIntegerInfo cii)
+{
+  char *s = (char *)malloc(256);
+  sprintf(s, "{\"integer\":%d}", cii.bytes);
+  return s;
+};
 
+// ConstantNameAndTypeInfo /////////////////////////////////////////////////////
 ConstantNameAndTypeInfo ConstantNameAndTypeInfo_read(FILE *fp)
 {
   ConstantNameAndTypeInfo cti;
@@ -187,15 +291,34 @@ ConstantNameAndTypeInfo ConstantNameAndTypeInfo_read(FILE *fp)
   return cti;
 };
 
-char *ConstantNameAndTypeInfo_to_string(ConstantNameAndTypeInfo cti)
+char *ConstantNameAndTypeInfo_get_utf8(
+    ConstantNameAndTypeInfo cti, ConstantPool cp)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\"}", cti.name_index, cti.descriptor_index);
+  char *name_utf8 = ConstantPool_get_utf8(cp, cti.name_index);
+  char *descriptor_utf8 = ConstantPool_get_utf8(cp, cti.descriptor_index);
+  sprintf(s, "%s:%s", name_utf8, descriptor_utf8);
+  free(name_utf8);
+  free(descriptor_utf8);
   return s;
 };
 
-// CpInfo //////////////////////////////////////////////////////////////////////////////////////////
+char *ConstantNameAndTypeInfo_to_string(
+    ConstantNameAndTypeInfo cti, ConstantPool cp)
+{
+  char *s = (char *)malloc(256);
+  char *name_utf8 = ConstantPool_get_utf8(cp, cti.name_index);
+  char *descriptor_utf8 = ConstantPool_get_utf8(cp, cti.descriptor_index);
+  snprintf(
+      s, 256,
+      "{\"name_index\":\"#%d // %s\",\"descriptor_index\":\"#%d // %s\"}",
+      cti.name_index, name_utf8, cti.descriptor_index, descriptor_utf8);
+  free(name_utf8);
+  free(descriptor_utf8);
+  return s;
+};
 
+// CpInfo //////////////////////////////////////////////////////////////////////
 CpInfo CpInfo_read(FILE *fp)
 {
   CpInfo ci;
@@ -224,7 +347,8 @@ CpInfo CpInfo_read(FILE *fp)
     ci.constant_class_info = ConstantClassInfo_read(fp);
     break;
   case CONSTANT_INTERFACE_METHOD_REF:
-    ci.constant_interface_methodref_info = ConstantInterfaceMethodrefInfo_read(fp);
+    ci.constant_interface_methodref_info =
+        ConstantInterfaceMethodrefInfo_read(fp);
     break;
   case CONSTANT_UTF8:
     ci.constant_utf8_info = ConstantUtf8Info_read(fp);
@@ -241,16 +365,16 @@ CpInfo CpInfo_read(FILE *fp)
   return ci;
 }
 
-char *CpInfo_to_string(CpInfo ci)
+char *CpInfo_to_string(CpInfo ci, ConstantPool cp)
 {
   char *s;
   switch (ci.tag)
   {
   case CONSTANT_METHODREF:
-    s = ConstantMethodrefInfo_to_string(ci.constant_methodref_info);
+    s = ConstantMethodrefInfo_to_string(ci.constant_methodref_info, cp);
     break;
   case CONSTANT_FIELDREF:
-    s = ConstantFieldrefInfo_to_string(ci.constant_fieldref_info);
+    s = ConstantFieldrefInfo_to_string(ci.constant_fieldref_info, cp);
     break;
   case CONSTANT_FLOAT:
     s = ConstantFloatInfo_to_string(ci.constant_float_info);
@@ -262,13 +386,14 @@ char *CpInfo_to_string(CpInfo ci)
     s = ConstantDoubleInfo_to_string(ci.constant_double_info);
     break;
   case CONSTANT_STRING:
-    s = ConstantStringInfo_to_string(ci.constant_string_info);
+    s = ConstantStringInfo_to_string(ci.constant_string_info, cp);
     break;
   case CONSTANT_CLASS:
-    s = ConstantClassInfo_to_string(ci.constant_class_info);
+    s = ConstantClassInfo_to_string(ci.constant_class_info, cp);
     break;
   case CONSTANT_INTERFACE_METHOD_REF:
-    s = ConstantInterfaceMethodrefInfo_to_string(ci.constant_interface_methodref_info);
+    s = ConstantInterfaceMethodrefInfo_to_string(
+        ci.constant_interface_methodref_info, cp);
     break;
   case CONSTANT_UTF8:
     s = ConstantUtf8Info_to_string(ci.constant_utf8_info);
@@ -277,7 +402,7 @@ char *CpInfo_to_string(CpInfo ci)
     s = ConstantIntegerInfo_to_string(ci.constant_integer_info);
     break;
   case CONSTANT_NAME_AND_TYPE:
-    s = ConstantNameAndTypeInfo_to_string(ci.constant_name_and_type_info);
+    s = ConstantNameAndTypeInfo_to_string(ci.constant_name_and_type_info, cp);
     break;
   default:
     s = (char *)malloc(256);
@@ -287,8 +412,7 @@ char *CpInfo_to_string(CpInfo ci)
   return s;
 }
 
-// ConstantPool ////////////////////////////////////////////////////////////////////////////////////
-
+// ConstantPool ////////////////////////////////////////////////////////////////
 ConstantPool ConstantPool_read(FILE *fp, u2 constant_pool_count)
 {
   ConstantPool cp = (CpInfo *)malloc((constant_pool_count + 1) * sizeof(CpInfo));
@@ -309,7 +433,7 @@ char *ConstantPool_to_string(ConstantPool cp, u2 constant_pool_count)
   snprintf(cp_string, 1000000, "{");
   for (int i = 1; i < constant_pool_count; i++)
   {
-    char *ci_string = CpInfo_to_string(cp[i]);
+    char *ci_string = CpInfo_to_string(cp[i], cp);
     char *final_string = (char *)malloc(1000000);
     char comma_string = i == constant_pool_count - 1 ? '}' : ',';
     snprintf(final_string, 1000000, "%s\"#%d\":%s%c", cp_string, i, ci_string, comma_string);
@@ -322,6 +446,54 @@ char *ConstantPool_to_string(ConstantPool cp, u2 constant_pool_count)
     }
   }
   return cp_string;
+}
+
+char *ConstantPool_get_utf8(ConstantPool cp, u2 index)
+{
+  CpInfo ci = cp[index];
+  char *utf8;
+  switch (ci.tag)
+  {
+  case CONSTANT_METHODREF:
+    utf8 = ConstantMethodrefInfo_get_utf8(ci.constant_methodref_info, cp);
+    break;
+  case CONSTANT_FIELDREF:
+    utf8 = ConstantFieldrefInfo_get_utf8(ci.constant_fieldref_info, cp);
+    break;
+  case CONSTANT_FLOAT:
+    utf8 = ConstantFloatInfo_get_utf8(ci.constant_float_info);
+    break;
+  case CONSTANT_LONG:
+    utf8 = ConstantLongInfo_get_utf8(ci.constant_long_info);
+    break;
+  case CONSTANT_DOUBLE:
+    utf8 = ConstantDoubleInfo_get_utf8(ci.constant_double_info);
+    break;
+  case CONSTANT_STRING:
+    utf8 = ConstantStringInfo_get_utf8(ci.constant_string_info, cp);
+    break;
+  case CONSTANT_CLASS:
+    utf8 = ConstantClassInfo_get_utf8(ci.constant_class_info, cp);
+    break;
+  case CONSTANT_INTERFACE_METHOD_REF:
+    utf8 = ConstantInterfaceMethodrefInfo_get_utf8(
+        ci.constant_interface_methodref_info, cp);
+    break;
+  case CONSTANT_UTF8:
+    utf8 = ConstantUtf8Info_get_utf8(ci.constant_utf8_info, cp);
+    break;
+  case CONSTANT_INTEGER:
+    utf8 = ConstantIntegerInfo_get_utf8(ci.constant_integer_info);
+    break;
+  case CONSTANT_NAME_AND_TYPE:
+    utf8 = ConstantNameAndTypeInfo_get_utf8(ci.constant_name_and_type_info, cp);
+    break;
+  default:
+    utf8 = (char *)malloc(16);
+    snprintf(utf8, 16, "null");
+    break;
+  }
+  return utf8;
 }
 
 void ConstantPool_free(ConstantPool cp, u2 constant_pool_count)

--- a/src/ConstantPool.c
+++ b/src/ConstantPool.c
@@ -15,7 +15,7 @@ ConstantMethodrefInfo ConstantMethodrefInfo_read(FILE *fp)
 char *ConstantMethodrefInfo_to_string(ConstantMethodrefInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantMethodrefInfo\",\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cfi.class_index, cfi.name_and_type_index);
+  sprintf(s, "{\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cfi.class_index, cfi.name_and_type_index);
   return s;
 };
 
@@ -32,7 +32,7 @@ ConstantFieldrefInfo ConstantFieldrefInfo_read(FILE *fp)
 char *ConstantFieldrefInfo_to_string(ConstantFieldrefInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantFieldrefInfo\",\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cfi.class_index, cfi.name_and_type_index);
+  sprintf(s, "{\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cfi.class_index, cfi.name_and_type_index);
   return s;
 };
 
@@ -51,7 +51,7 @@ ConstantFloatInfo ConstantFloatInfo_read(FILE *fp)
 char *ConstantFloatInfo_to_string(ConstantFloatInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantFloatInfo\",\"bytes\":%f}", cfi.bytes);
+  sprintf(s, "{\"bytes\":%f}", cfi.bytes);
   return s;
 };
 
@@ -69,7 +69,7 @@ ConstantLongInfo ConstantLongInfo_read(FILE *fp)
 char *ConstantLongInfo_to_string(ConstantLongInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantLongInfo\",\"bytes\":%ld}", cfi.bytes);
+  sprintf(s, "{\"bytes\":%ld}", cfi.bytes);
   return s;
 };
 
@@ -89,7 +89,7 @@ ConstantDoubleInfo ConstantDoubleInfo_read(FILE *fp)
 char *ConstantDoubleInfo_to_string(ConstantDoubleInfo cfi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantDoubleInfo\",\"bytes\":%f}", cfi.bytes);
+  sprintf(s, "{\"bytes\":%f}", cfi.bytes);
   return s;
 };
 
@@ -105,7 +105,7 @@ ConstantStringInfo ConstantStringInfo_read(FILE *fp)
 char *ConstantStringInfo_to_string(ConstantStringInfo csi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantStringInfo\",\"string_index\":\"#%d\"}", csi.string_index);
+  sprintf(s, "{\"string_index\":\"#%d\"}", csi.string_index);
   return s;
 };
 
@@ -121,7 +121,7 @@ ConstantClassInfo ConstantClassInfo_read(FILE *fp)
 char *ConstantClassInfo_to_string(ConstantClassInfo cci)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantClassInfo\",\"name_index\":\"#%d\"}", cci.name_index);
+  sprintf(s, "{\"name_index\":\"#%d\"}", cci.name_index);
   return s;
 };
 
@@ -138,7 +138,7 @@ ConstantInterfaceMethodrefInfo ConstantInterfaceMethodrefInfo_read(FILE *fp)
 char *ConstantInterfaceMethodrefInfo_to_string(ConstantInterfaceMethodrefInfo cimi)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantInterfaceMethodrefInfo\",\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cimi.class_index, cimi.name_and_type_index);
+  sprintf(s, "{\"class_index\":\"#%d\",\"name_and_type_index\":\"#%d\"}", cimi.class_index, cimi.name_and_type_index);
   return s;
 };
 
@@ -157,7 +157,7 @@ ConstantUtf8Info ConstantUtf8Info_read(FILE *fp)
 char *ConstantUtf8Info_to_string(ConstantUtf8Info cui)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantUtf8Info\",\"length\":%d,\"bytes\":\"%s\"}", cui.length, cui.bytes);
+  sprintf(s, "{\"length\":%d,\"bytes\":\"%s\"}", cui.length, cui.bytes);
   return s;
 };
 
@@ -173,7 +173,7 @@ ConstantIntegerInfo ConstantIntegerInfo_read(FILE *fp)
 char *ConstantIntegerInfo_to_string(ConstantIntegerInfo cii)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantIntegerInfo\",\"bytes\":%d}", cii.bytes);
+  sprintf(s, "{\"bytes\":%d}", cii.bytes);
   return s;
 };
 
@@ -190,7 +190,7 @@ ConstantNameAndTypeInfo ConstantNameAndTypeInfo_read(FILE *fp)
 char *ConstantNameAndTypeInfo_to_string(ConstantNameAndTypeInfo cti)
 {
   char *s = (char *)malloc(256);
-  sprintf(s, "{\"__cls\":\"ConstantNameAndTypeInfo\",\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\"}", cti.name_index, cti.descriptor_index);
+  sprintf(s, "{\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\"}", cti.name_index, cti.descriptor_index);
   return s;
 };
 
@@ -306,7 +306,7 @@ ConstantPool ConstantPool_read(FILE *fp, u2 constant_pool_count)
 char *ConstantPool_to_string(ConstantPool cp, u2 constant_pool_count)
 {
   char *cp_string = (char *)malloc(1000000);
-  snprintf(cp_string, 1000000, "{\"__cls\":\"ConstantPool\",");
+  snprintf(cp_string, 1000000, "{");
   for (int i = 1; i < constant_pool_count; i++)
   {
     char *ci_string = CpInfo_to_string(cp[i]);
@@ -324,14 +324,17 @@ char *ConstantPool_to_string(ConstantPool cp, u2 constant_pool_count)
   return cp_string;
 }
 
-
-void ConstantPool_free(ConstantPool cp, u2 constant_pool_count) {
+void ConstantPool_free(ConstantPool cp, u2 constant_pool_count)
+{
 
   for (int i = 1; i < constant_pool_count; i++)
   {
-    if (cp[i].tag == CONSTANT_UTF8){
+    if (cp[i].tag == CONSTANT_UTF8)
+    {
       free(cp[i].constant_utf8_info.bytes);
-    } else if (cp[i].tag == CONSTANT_LONG || cp[i].tag == CONSTANT_DOUBLE){
+    }
+    else if (cp[i].tag == CONSTANT_LONG || cp[i].tag == CONSTANT_DOUBLE)
+    {
       i++;
     }
   }

--- a/src/ConstantPool.h
+++ b/src/ConstantPool.h
@@ -104,4 +104,6 @@ ConstantPool ConstantPool_read(FILE *fp, u2 constant_pool_count);
 
 char *ConstantPool_to_string(ConstantPool cp, u2 constant_pool_count);
 
+char *ConstantPool_get_utf8(ConstantPool cp, u2 index);
+
 void ConstantPool_free(ConstantPool cp, u2 constant_pool_count);

--- a/src/Field.c
+++ b/src/Field.c
@@ -3,6 +3,7 @@
 #include "java-bytes.h"
 #include <stdio.h>  // sprintf
 #include <stdlib.h> // malloc
+#include <string.h> // strlen
 
 FieldInfo *FieldInfo_read(FILE *fp, u2 fields_count, ConstantPool constant_pool)
 {
@@ -30,6 +31,31 @@ void FieldInfo_free(FieldInfo *field_infos, u2 fields_count, ConstantPool consta
   free(field_infos);
 }
 
+char *FieldInfo_access_flags_to_string(u2 access_flags)
+{
+  const char *public_string = access_flags & 0x0001 ? "public " : "";
+  const char *private_string = access_flags & 0x0002 ? "private " : "";
+  const char *protected_string = access_flags & 0x0004 ? "protected " : "";
+  const char *static_string = access_flags & 0x0008 ? "static " : "";
+  const char *final_string = access_flags & 0x0010 ? "final " : "";
+  const char *volatile_string = access_flags & 0x0040 ? "volatile " : "";
+  const char *transient_string = access_flags & 0x0080 ? "transient " : "";
+  const char *synthetic_string = access_flags & 0x1000 ? "synthetic " : "";
+  const char *enum_string = access_flags & 0x4000 ? "enum " : "";
+  char *str = (char *)malloc(1024 * sizeof(char));
+  snprintf(
+      str, 1024,
+      "%s%s%s%s%s%s%s%s%s",
+      public_string, private_string, protected_string, static_string,
+      final_string, volatile_string, transient_string, synthetic_string,
+      enum_string);
+  if (strlen(str) > 0)
+  {
+    str[strlen(str) - 1] = '\0'; // remove last space
+  }
+  return str;
+}
+
 char *FieldInfo_to_string(FieldInfo *field_infos, u2 fields_count, ConstantPool constant_pool)
 {
   char *str = (char *)malloc(65536 * sizeof(char));
@@ -41,6 +67,8 @@ char *FieldInfo_to_string(FieldInfo *field_infos, u2 fields_count, ConstantPool 
   snprintf(str, 65536, "[");
   for (FieldInfo *field_info = field_infos; field_info < field_infos + fields_count; field_info++)
   {
+    char *access_flags_str = FieldInfo_access_flags_to_string(
+        field_info->access_flags);
     char *attribute_info_str = AttributeInfo_to_string(
         field_info->attributes, field_info->attributes_count, constant_pool);
     char separator = field_info == field_infos + fields_count - 1 ? ']' : ',';
@@ -51,12 +79,13 @@ char *FieldInfo_to_string(FieldInfo *field_infos, u2 fields_count, ConstantPool 
         constant_pool, field_info->descriptor_index);
     snprintf(
         str_temp, 65536,
-        "%s{\"access_flags\": \"0x%X\",\"name_index\":\"#%d // %s\","
-        "\"descriptor_index\":\"#%d // %s\",\"attributes_count\":%d,"
-        "\"attributes\":%s}%c",
-        str, field_info->access_flags, field_info->name_index, name_utf8,
-        field_info->descriptor_index, descriptor_utf8, field_info->attributes_count,
-        attribute_info_str, separator);
+        "%s{\"access_flags\": \"0x%04X [%s]\",\"name_index\":\"#%d // %s\","
+        "\"descriptor_index\":\"#%d // %s\","
+        "\"attributes_count\":%d,\"attributes\":%s}%c",
+        str, field_info->access_flags, access_flags_str, field_info->name_index,
+        name_utf8, field_info->descriptor_index, descriptor_utf8,
+        field_info->attributes_count, attribute_info_str, separator);
+    free(access_flags_str);
     free(name_utf8);
     free(descriptor_utf8);
     free(attribute_info_str);

--- a/src/Field.c
+++ b/src/Field.c
@@ -47,7 +47,7 @@ char *FieldInfo_to_string(FieldInfo *field_infos, u2 fields_count, ConstantPool 
     char *str_temp = (char *)malloc(65536 * sizeof(char));
     snprintf(
         str_temp, 65536,
-        "%s{\"__cls\":\"FieldInfo\",\"access_flags\": \"0x%X\",\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\",\"attributes_count\":%d,\"attributes\":%s}%c",
+        "%s{\"access_flags\": \"0x%X\",\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\",\"attributes_count\":%d,\"attributes\":%s}%c",
         str, field_info->access_flags, field_info->name_index, field_info->descriptor_index,
         field_info->attributes_count, attribute_info_str, separator);
     free(attribute_info_str);

--- a/src/Field.c
+++ b/src/Field.c
@@ -45,11 +45,20 @@ char *FieldInfo_to_string(FieldInfo *field_infos, u2 fields_count, ConstantPool 
         field_info->attributes, field_info->attributes_count, constant_pool);
     char separator = field_info == field_infos + fields_count - 1 ? ']' : ',';
     char *str_temp = (char *)malloc(65536 * sizeof(char));
+    char *name_utf8 = ConstantPool_get_utf8(
+        constant_pool, field_info->name_index);
+    char *descriptor_utf8 = ConstantPool_get_utf8(
+        constant_pool, field_info->descriptor_index);
     snprintf(
         str_temp, 65536,
-        "%s{\"access_flags\": \"0x%X\",\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\",\"attributes_count\":%d,\"attributes\":%s}%c",
-        str, field_info->access_flags, field_info->name_index, field_info->descriptor_index,
-        field_info->attributes_count, attribute_info_str, separator);
+        "%s{\"access_flags\": \"0x%X\",\"name_index\":\"#%d // %s\","
+        "\"descriptor_index\":\"#%d // %s\",\"attributes_count\":%d,"
+        "\"attributes\":%s}%c",
+        str, field_info->access_flags, field_info->name_index, name_utf8,
+        field_info->descriptor_index, descriptor_utf8, field_info->attributes_count,
+        attribute_info_str, separator);
+    free(name_utf8);
+    free(descriptor_utf8);
     free(attribute_info_str);
     free(str);
     str = str_temp;

--- a/src/Method.c
+++ b/src/Method.c
@@ -43,12 +43,21 @@ char *MethodInfo_to_string(MethodInfo *method_infos, u2 methods_count, ConstantP
     char *attributes_str = AttributeInfo_to_string(
         method_info->attributes, method_info->attributes_count, constant_pool);
     char comma = method_info == method_infos + methods_count - 1 ? ']' : ',';
+    char *name_utf8 = ConstantPool_get_utf8(
+        constant_pool, method_info->name_index);
+    char *descriptor_utf8 = ConstantPool_get_utf8(
+        constant_pool, method_info->descriptor_index);
     snprintf(
         tmp, 65536,
-        "%s{\"access_flags\":\"0x%X\",\"name_index\":\"#%d\",\"descriptor_index\":\"#%d\", \"attributes_count\":%d,\"attributes\":%s}%c",
+        "%s{\"access_flags\":\"0x%X\",\"name_index\":\"#%d // %s\","
+        "\"descriptor_index\":\"#%d // %s\", \"attributes_count\":%d,"
+        "\"attributes\":%s}%c",
         methods_string, method_info->access_flags, method_info->name_index,
-        method_info->descriptor_index, method_info->attributes_count, attributes_str, comma);
+        name_utf8, method_info->descriptor_index, descriptor_utf8,
+        method_info->attributes_count, attributes_str, comma);
     free(attributes_str);
+    free(name_utf8);
+    free(descriptor_utf8);
     free(methods_string);
     methods_string = tmp;
   }

--- a/src/Method.c
+++ b/src/Method.c
@@ -3,6 +3,7 @@
 #include "java-bytes.h"
 #include <stdio.h>  // sprintf
 #include <stdlib.h> // malloc
+#include <string.h> // strlen
 
 MethodInfo *MethodInfo_read(FILE *fp, u2 methods_count, ConstantPool constant_pool)
 {
@@ -29,6 +30,34 @@ void MethodInfo_free(MethodInfo *method_info, u2 methods_count, ConstantPool con
   free(method_info);
 }
 
+char *MethodInfo_access_flags_to_string(u2 access_flags)
+{
+  const char *public_string = access_flags & 0x0001 ? "public " : "";
+  const char *private_string = access_flags & 0x0002 ? "private " : "";
+  const char *protected_string = access_flags & 0x0004 ? "protected " : "";
+  const char *static_string = access_flags & 0x0008 ? "static " : "";
+  const char *final_string = access_flags & 0x0010 ? "final " : "";
+  const char *synchronized_string = access_flags & 0x0020 ? "synchronized " : "";
+  const char *bridge_string = access_flags & 0x0040 ? "bridge " : "";
+  const char *varargs_string = access_flags & 0x0080 ? "varargs " : "";
+  const char *native_string = access_flags & 0x0100 ? "native " : "";
+  const char *abstract_string = access_flags & 0x0400 ? "abstract " : "";
+  const char *strict_string = access_flags & 0x0800 ? "strict " : "";
+  const char *synthetic_string = access_flags & 0x1000 ? "synthetic " : "";
+  char *access_flags_string = (char *)malloc(1024);
+  snprintf(
+      access_flags_string, 1024,
+      "%s%s%s%s%s%s%s%s%s%s%s%s",
+      public_string, private_string, protected_string, static_string,
+      final_string, synchronized_string, bridge_string, varargs_string,
+      native_string, abstract_string, strict_string, synthetic_string);
+  if (strlen(access_flags_string) > 0)
+  {
+    access_flags_string[strlen(access_flags_string) - 1] = '\0'; // remove trailing space;
+  }
+  return access_flags_string;
+}
+
 char *MethodInfo_to_string(MethodInfo *method_infos, u2 methods_count, ConstantPool constant_pool)
 {
   char *methods_string = (char *)malloc(65536);
@@ -40,6 +69,8 @@ char *MethodInfo_to_string(MethodInfo *method_infos, u2 methods_count, ConstantP
   for (MethodInfo *method_info = method_infos; method_info < method_infos + methods_count; method_info++)
   {
     char *tmp = (char *)malloc(65536);
+    char *access_flags_string = MethodInfo_access_flags_to_string(
+        method_info->access_flags);
     char *attributes_str = AttributeInfo_to_string(
         method_info->attributes, method_info->attributes_count, constant_pool);
     char comma = method_info == method_infos + methods_count - 1 ? ']' : ',';
@@ -49,12 +80,15 @@ char *MethodInfo_to_string(MethodInfo *method_infos, u2 methods_count, ConstantP
         constant_pool, method_info->descriptor_index);
     snprintf(
         tmp, 65536,
-        "%s{\"access_flags\":\"0x%X\",\"name_index\":\"#%d // %s\","
+        "%s{\"access_flags\":\"0x%04X [%s]\","
+        "\"name_index\":\"#%d // %s\","
         "\"descriptor_index\":\"#%d // %s\", \"attributes_count\":%d,"
         "\"attributes\":%s}%c",
-        methods_string, method_info->access_flags, method_info->name_index,
-        name_utf8, method_info->descriptor_index, descriptor_utf8,
+        methods_string, method_info->access_flags, access_flags_string,
+        method_info->name_index, name_utf8,
+        method_info->descriptor_index, descriptor_utf8,
         method_info->attributes_count, attributes_str, comma);
+    free(access_flags_string);
     free(attributes_str);
     free(name_utf8);
     free(descriptor_utf8);


### PR DESCRIPTION
- [x] Mapear minor e major version para versão do Java.
- [x] Retirar os atributos __cls do JSON;
- [x] Referências aos índices do _constant pool_ podem devem ser posfixados com `// <UTF8 do constant pool>`
- [x] Números relacionados aos access_flags devem ser posfixados com `// [public | protected | private] [final] [...]` 
- [ ] Formatar os instructions para que fiquem legíveis (não em hexadecima);